### PR TITLE
ImmersiveHud_fix

### DIFF
--- a/ImmersiveHud/Hud_Update_Patch.cs
+++ b/ImmersiveHud/Hud_Update_Patch.cs
@@ -1,11 +1,15 @@
 ﻿using UnityEngine;
 using HarmonyLib;
+using System;
+using System.Reflection;
 
 namespace ImmersiveHud
 {
     [HarmonyPatch(typeof(Hud), "Update")]
     public class Hud_Update_Patch : ImmersiveHud
     {
+        private static MethodInfo _GetRightItemMethod = AccessTools.Method(typeof(Humanoid), "GetRightItem");
+        private static MethodInfo _GetLeftItemMethod = AccessTools.Method(typeof(Humanoid), "GetLeftItem");
         public static void updateHudElementTransparency(HudElement hudElement)
         {
             float lerpedAlpha;
@@ -33,8 +37,8 @@ namespace ImmersiveHud
 
             getPlayerTotalFoodValue(player);
 
-            ItemDrop.ItemData playerItemEquippedLeft = player.GetLeftItem();
-            ItemDrop.ItemData playerItemEquippedRight = player.GetRightItem();
+            ItemDrop.ItemData playerItemEquippedLeft = _GetLeftItemMethod.Invoke(player, Array.Empty<object>()) as ItemDrop.ItemData;
+            ItemDrop.ItemData playerItemEquippedRight = _GetRightItemMethod.Invoke(player, Array.Empty<object>()) as ItemDrop.ItemData;
 
             if (playerItemEquippedLeft != null || playerItemEquippedRight != null)
                 playerHasItemEquipped = true;

--- a/ImmersiveHud/Player_Update_Patch.cs
+++ b/ImmersiveHud/Player_Update_Patch.cs
@@ -1,18 +1,21 @@
 ﻿using UnityEngine;
 using HarmonyLib;
 using System.Reflection;
+using System;
 
 namespace ImmersiveHud
 {
     [HarmonyPatch(typeof(Player), "Update")]
     public class Player_Update_Patch : ImmersiveHud
     {
+        private static MethodInfo _GetRightItemMethod = AccessTools.Method(typeof(Humanoid), "GetRightItem");
+        private static MethodInfo _GetLeftItemMethod = AccessTools.Method(typeof(Humanoid), "GetLeftItem");
         private static void Prefix(Player __instance)
         {
             if (!__instance) return;
 
-            ItemDrop.ItemData playerItemEquippedLeft = __instance.GetLeftItem();
-            ItemDrop.ItemData playerItemEquippedRight = __instance.GetRightItem();
+            ItemDrop.ItemData playerItemEquippedLeft = _GetLeftItemMethod.Invoke(__instance, Array.Empty<object>()) as ItemDrop.ItemData;
+            ItemDrop.ItemData playerItemEquippedRight = _GetRightItemMethod.Invoke(__instance, Array.Empty<object>()) as ItemDrop.ItemData;
 
             if (playerItemEquippedLeft != null && (playerItemEquippedLeft.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Bow))
             {


### PR DESCRIPTION
Address the change of GetRightItem and GetLeftItem to protected variables on the Humanoid class.

Fix stolen from MassFarming
https://github.com/Xeio/MassFarming/commit/6298988921e7a852d7fa2c95b777c3dc0b8f3e98